### PR TITLE
Fix security vulnerabilities in PKCE OAuth flow and credential storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,17 @@
 import { Routes, Route, Navigate } from "react-router-dom";
+import { WalletProvider } from "./context/WalletProvider";
 import { Callback } from "./pages/Callback";
 import { WalletHome } from "./pages/WalletHome";
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<WalletHome />} />
-      <Route path="/callback" element={<Callback />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <WalletProvider>
+      <Routes>
+        <Route path="/" element={<WalletHome />} />
+        <Route path="/callback" element={<Callback />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </WalletProvider>
   );
 }
 

--- a/src/components/PassphraseGate.tsx
+++ b/src/components/PassphraseGate.tsx
@@ -1,30 +1,10 @@
 import { useState } from "react";
-import { setSessionKey } from "../lib/session";
+import { deriveKey } from "@lib/crypto";
+import { getOrCreateSalt } from "@lib/credential-store";
+import { useWallet } from "../context/useWallet";
 
-interface Props {
-  onUnlock: () => void;
-}
-
-async function deriveKey(passphrase: string): Promise<CryptoKey> {
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(passphrase),
-    "PBKDF2",
-    false,
-    ["deriveKey"],
-  );
-
-  const salt = new TextEncoder().encode("#4 placeholder-salt"); //will replaced one #4 is done
-  return crypto.subtle.deriveKey(
-    { name: "PBKDF2", salt, iterations: 310_000, hash: "SHA-256" },
-    keyMaterial,
-    { name: "AES-GCM", length: 256 },
-    false,
-    ["encrypt", "decrypt"],
-  );
-}
-
-export function PassphraseGate({ onUnlock }: Props) {
+export function PassphraseGate() {
+  const { unlock } = useWallet();
   const [passphrase, setPassphrase] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -33,15 +13,17 @@ export function PassphraseGate({ onUnlock }: Props) {
     if (!passphrase) return;
     setLoading(true);
     setError(null);
-    try {
-      const key = await deriveKey(passphrase);
-      setSessionKey(key);
-      onUnlock();
-    } catch {
-      setError("Failed to unlock wallet. Please try again.");
-    } finally {
-      setLoading(false);
-    }
+
+    const result = await getOrCreateSalt().andThen((salt) =>
+      deriveKey(passphrase, salt),
+    );
+
+    result.match(
+      (key) => unlock(key),
+      () => setError("Failed to unlock wallet. Please try again."),
+    );
+
+    setLoading(false);
   }
 
   return (

--- a/src/context/WalletProvider.tsx
+++ b/src/context/WalletProvider.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import { WalletContext } from "./useWallet";
+import { setSessionKey, clearSessionKey } from "../lib/session";
+
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [key, setKey] = useState<CryptoKey | null>(null);
+
+  function unlock(cryptoKey: CryptoKey) {
+    setSessionKey(cryptoKey);
+    setKey(cryptoKey);
+  }
+
+  function lock() {
+    clearSessionKey();
+    setKey(null);
+  }
+
+  return (
+    <WalletContext.Provider value={{ key, unlock, lock }}>
+      {children}
+    </WalletContext.Provider>
+  );
+}

--- a/src/context/useWallet.ts
+++ b/src/context/useWallet.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+export interface WalletContextValue {
+  key: CryptoKey | null;
+  unlock: (key: CryptoKey) => void;
+  lock: () => void;
+}
+
+export const WalletContext = createContext<WalletContextValue | null>(null);
+
+export function useWallet(): WalletContextValue {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used within WalletProvider");
+  return ctx;
+}

--- a/src/lib/api/keycloak.ts
+++ b/src/lib/api/keycloak.ts
@@ -41,7 +41,7 @@ async function generatePKCE(): Promise<PKCEPair> {
 export interface AuthRequest {
   url: string;
   codeVerifier: string;
-  state: string; // added this part as security parameter to prevent Cross Site Request Forgery attack, can remove if you think we dont need it
+  state: string;
 }
 
 export async function createAuthRequest(idp: IdP): Promise<AuthRequest> {

--- a/src/lib/credential-store.ts
+++ b/src/lib/credential-store.ts
@@ -1,4 +1,4 @@
-import { ResultAsync } from "neverthrow";
+import { ok, err, ResultAsync } from "neverthrow";
 import type { VerifiableCredential } from "@lib/types";
 import { encrypt, decrypt, type EncryptedData } from "@lib/crypto";
 
@@ -9,12 +9,12 @@ export interface CredentialStoreError {
 const DB_NAME = "zeroverify-wallet";
 const DB_VERSION = 1;
 const STORE_NAME = "credentials";
+const METADATA_STORE_NAME = "metadata";
 
 interface StoredCredential {
   id: string;
   ciphertext: ArrayBuffer;
   iv: ArrayBuffer;
-  encrypted: boolean;
   stored_at: string;
 }
 
@@ -32,6 +32,9 @@ function openDatabase(): ResultAsync<IDBDatabase, CredentialStoreError> {
         if (!db.objectStoreNames.contains(STORE_NAME)) {
           const store = db.createObjectStore(STORE_NAME, { keyPath: "id" });
           store.createIndex("stored_at", "stored_at", { unique: false });
+        }
+        if (!db.objectStoreNames.contains(METADATA_STORE_NAME)) {
+          db.createObjectStore(METADATA_STORE_NAME, { keyPath: "key" });
         }
       };
     }),
@@ -64,7 +67,6 @@ export function storeCredential(
               id: credential.id,
               ciphertext: encrypted.ciphertext,
               iv: encrypted.iv.buffer as ArrayBuffer,
-              encrypted: true,
               stored_at: new Date().toISOString(),
             };
 
@@ -118,12 +120,20 @@ export function getAllCredentials(
           iv: new Uint8Array(item.iv),
         };
         return decrypt(key, encryptedData)
-          .map((json) => JSON.parse(json) as VerifiableCredential)
           .mapErr(
             (e): CredentialStoreError => ({
               message: `Decryption failed: ${e.message}`,
             }),
-          );
+          )
+          .andThen((json) => {
+            try {
+              return ok(JSON.parse(json) as VerifiableCredential);
+            } catch {
+              return err<VerifiableCredential, CredentialStoreError>({
+                message: "Failed to parse credential data",
+              });
+            }
+          });
       });
 
       return ResultAsync.combine(decryptPromises);
@@ -166,12 +176,20 @@ export function getCredential(
       };
 
       return decrypt(key, encryptedData)
-        .map((json) => JSON.parse(json) as VerifiableCredential)
         .mapErr(
           (e): CredentialStoreError => ({
             message: `Decryption failed: ${e.message}`,
           }),
-        );
+        )
+        .andThen((json) => {
+          try {
+            return ok(JSON.parse(json) as VerifiableCredential);
+          } catch {
+            return err<VerifiableCredential, CredentialStoreError>({
+              message: "Failed to parse credential data",
+            });
+          }
+        });
     }),
   );
 }
@@ -198,6 +216,55 @@ export function deleteCredential(
       }),
       (e) => ({
         message: e instanceof Error ? e.message : "Deletion error",
+      }),
+    ),
+  );
+}
+
+export function getOrCreateSalt(): ResultAsync<
+  Uint8Array<ArrayBuffer>,
+  CredentialStoreError
+> {
+  return openDatabase().andThen((db) =>
+    ResultAsync.fromPromise(
+      new Promise<Uint8Array<ArrayBuffer>>((resolve, reject) => {
+        const transaction = db.transaction([METADATA_STORE_NAME], "readwrite");
+        const store = transaction.objectStore(METADATA_STORE_NAME);
+        const getRequest = store.get("pbkdf2_salt");
+
+        getRequest.onsuccess = () => {
+          if (getRequest.result) {
+            db.close();
+            resolve(new Uint8Array(getRequest.result.value as ArrayBuffer));
+            return;
+          }
+
+          const salt = crypto.getRandomValues(
+            new Uint8Array(16) as Uint8Array<ArrayBuffer>,
+          );
+          const putRequest = store.put({
+            key: "pbkdf2_salt",
+            value: salt.buffer,
+          });
+
+          putRequest.onsuccess = () => {
+            db.close();
+            resolve(salt);
+          };
+
+          putRequest.onerror = () => {
+            db.close();
+            reject(new Error("Failed to store salt"));
+          };
+        };
+
+        getRequest.onerror = () => {
+          db.close();
+          reject(new Error("Failed to retrieve salt"));
+        };
+      }),
+      (e) => ({
+        message: e instanceof Error ? e.message : "Salt error",
       }),
     ),
   );

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -9,6 +9,33 @@ export interface EncryptedData {
   iv: Uint8Array<ArrayBuffer>;
 }
 
+export function deriveKey(
+  passphrase: string,
+  salt: Uint8Array<ArrayBuffer>,
+): ResultAsync<CryptoKey, CryptoError> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      const keyMaterial = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(passphrase),
+        "PBKDF2",
+        false,
+        ["deriveKey"],
+      );
+      return crypto.subtle.deriveKey(
+        { name: "PBKDF2", salt, iterations: 310_000, hash: "SHA-256" },
+        keyMaterial,
+        { name: "AES-GCM", length: 256 },
+        false,
+        ["encrypt", "decrypt"],
+      );
+    })(),
+    (e) => ({
+      message: e instanceof Error ? e.message : "Key derivation failed",
+    }),
+  );
+}
+
 export function encrypt(
   key: CryptoKey,
   data: string,

--- a/src/pages/Callback.tsx
+++ b/src/pages/Callback.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { issueCredential } from "@lib/api/issuance";
-import { getSessionKey } from "../lib/session";
+import { useWallet } from "../context/useWallet";
 import { storeCredential } from "@lib/credential-store";
+import { PassphraseGate } from "../components/PassphraseGate";
 
 function getErrorMessage(status: number | undefined): string {
   switch (status) {
@@ -21,6 +22,7 @@ function getErrorMessage(status: number | undefined): string {
 
 export function Callback() {
   const navigate = useNavigate();
+  const { key } = useWallet();
   const [error, setError] = useState<string | null>(() => {
     const params = new URLSearchParams(window.location.search);
     const oauthError = params.get("error");
@@ -44,7 +46,7 @@ export function Callback() {
   });
 
   useEffect(() => {
-    if (error) return;
+    if (error || !key) return;
 
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
@@ -55,29 +57,29 @@ export function Callback() {
     sessionStorage.removeItem("oauth_state");
     sessionStorage.removeItem("pkce_verifier");
 
-    const key = getSessionKey();
-    if (!key) {
-      navigate("/", {
-        state: { pendingCode: code, pendingVerifier: verifier },
-      });
-      return;
-    }
+    let cancelled = false;
 
-    issueCredential(code, verifier).then((result) =>
+    issueCredential(code, verifier).then((result) => {
+      if (cancelled) return;
       result.match(
         (credential) => {
-          storeCredential(credential, key).then((storeResult) =>
+          storeCredential(credential, key).then((storeResult) => {
+            if (cancelled) return;
             storeResult.match(
               () => navigate("/"),
               (storeErr) =>
                 setError(`Failed to store credential: ${storeErr.message}`),
-            ),
-          );
+            );
+          });
         },
         (err) => setError(getErrorMessage(err.status)),
-      ),
-    );
-  }, [navigate, error]);
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate, error, key]);
 
   if (error) {
     return (
@@ -87,6 +89,10 @@ export function Callback() {
         <button onClick={() => navigate("/")}>Go back</button>
       </div>
     );
+  }
+
+  if (!key) {
+    return <PassphraseGate />;
   }
 
   return (

--- a/src/pages/WalletHome.tsx
+++ b/src/pages/WalletHome.tsx
@@ -1,35 +1,33 @@
 import { useState, useEffect } from "react";
 import { PassphraseGate } from "../components/PassphraseGate";
-import { isUnlocked, getSessionKey } from "../lib/session";
+import { useWallet } from "../context/useWallet";
 import { createAuthRequest, SUPPORTED_IDPS } from "@lib/api/keycloak";
 import { getAllCredentials } from "@lib/credential-store";
 import type { VerifiableCredential } from "@lib/types";
 
 export function WalletHome() {
-  const [unlocked, setUnlocked] = useState(isUnlocked());
+  const { key } = useWallet();
   const [credentials, setCredentials] = useState<VerifiableCredential[]>([]);
-  const [loading, setLoading] = useState(isUnlocked());
+  const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!unlocked) return;
+  const loading = key !== null && !loaded;
 
-    const key = getSessionKey();
+  useEffect(() => {
     if (!key) return;
 
     let cancelled = false;
 
     getAllCredentials(key).then((result) => {
       if (cancelled) return;
-
       result.match(
         (creds) => {
           setCredentials(creds);
-          setLoading(false);
+          setLoaded(true);
         },
         (err) => {
           setError(`Failed to load credentials: ${err.message}`);
-          setLoading(false);
+          setLoaded(true);
         },
       );
     });
@@ -37,18 +35,22 @@ export function WalletHome() {
     return () => {
       cancelled = true;
     };
-  }, [unlocked]);
+  }, [key]);
 
-  if (!unlocked) {
-    return <PassphraseGate onUnlock={() => setUnlocked(true)} />;
+  if (!key) {
+    return <PassphraseGate />;
   }
 
   async function handleGetCredential() {
-    const idp = SUPPORTED_IDPS[0];
-    const { url, codeVerifier, state } = await createAuthRequest(idp);
-    sessionStorage.setItem("pkce_verifier", codeVerifier);
-    sessionStorage.setItem("oauth_state", state);
-    window.location.href = url;
+    try {
+      const idp = SUPPORTED_IDPS[0];
+      const { url, codeVerifier, state } = await createAuthRequest(idp);
+      sessionStorage.setItem("pkce_verifier", codeVerifier);
+      sessionStorage.setItem("oauth_state", state);
+      window.location.href = url;
+    } catch {
+      setError("Failed to start authentication. Please try again.");
+    }
   }
 
   return (


### PR DESCRIPTION
### Notes

1. The PBKDF2 salt was a hardcoded string shared by every user. A static salt defeats the entire purpose - an attacker who builds one precomputed table for that salt can crack any wallet's passphrase offline. A random 16-byte salt is
   now generated on first unlock and stored in a new metadata IndexedDB object store. deriveKey is moved to crypto.ts and takes the salt as a parameter so there is one canonical implementation.

2. When the callback arrived with the wallet locked, the authorization code and PKCE verifier were forwarded to WalletHome via React Router's navigate state, which lands in window.history.state and is accessible to any script on the
  page. The fix keeps the entire issuance flow inside Callback: if the wallet is locked it renders PassphraseGate inline, and once the user unlocks, the effect re-fires with the key and completes issuance before redirecting to /.

3. JSON.parse inside a neverthrow .map() was throwing on malformed data, which escapes the error chain and becomes an unhandled promise rejection invisible to the caller. Replaced with .andThen() + try/catch so parse failures come
  back as Err.

4. WalletContext was added (WalletProvider + useWallet) to make unlock state a proper React signal. Previously components called useState(isUnlocked()) which only read the module singleton at mount time and wouldn't react to changes. With context, any component re-renders when the wallet locks or unlocks - which also makes adding an auto-lock timeout straightforward in the future.

###  Testing

  1. `npm run lint`  
  2. `npm run build`