### PR TITLE
feat: credential view with revocation status badge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to S3 + CloudFront
+name: Deploy to GitHub Pages
 
 on:
   push:
@@ -7,10 +7,11 @@ on:
 
 permissions:
   contents: read
+  pages: write
   id-token: write
 
 concurrency:
-  group: deploy
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -30,42 +31,16 @@ jobs:
 
       - run: cp dist/index.html dist/404.html
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
-          name: dist
           path: dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: production
-      url: https://wallet.zeroverify.net
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::043189681060:role/ZeroVerifyGitHubActionsWalletDeployment
-          aws-region: us-east-1
-
-      - name: Sync to S3
-        run: |
-          aws s3 sync dist/ s3://WALLET_BUCKET_PLACEHOLDER \
-            --delete \
-            --cache-control "public,max-age=31536000,immutable" \
-            --exclude "index.html" \
-            --exclude "404.html"
-          aws s3 cp dist/index.html s3://WILL_ADD_WALLET_S3/index.html \
-            --cache-control "no-cache,no-store,must-revalidate"
-          aws s3 cp dist/404.html s3://WILL_ADD_WALLET_S3/404.html \
-            --cache-control "no-cache,no-store,must-revalidate"
-
-      - name: Invalidate CloudFront cache
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id WILL_ADD_CLOUDFRONT_DISTRIBUTION_ID \
-            --paths "/*"
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy to S3 + CloudFront
 
 on:
   push:
@@ -7,11 +7,10 @@ on:
 
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 concurrency:
-  group: pages
+  group: deploy
   cancel-in-progress: false
 
 jobs:
@@ -31,16 +30,42 @@ jobs:
 
       - run: cp dist/index.html dist/404.html
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: dist
           path: dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      name: production
+      url: https://wallet.zeroverify.net
     steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::043189681060:role/ZeroVerifyGitHubActionsWalletDeployment
+          aws-region: us-east-1
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync dist/ s3://WALLET_BUCKET_PLACEHOLDER \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable" \
+            --exclude "index.html" \
+            --exclude "404.html"
+          aws s3 cp dist/index.html s3://WILL_ADD_WALLET_S3/index.html \
+            --cache-control "no-cache,no-store,must-revalidate"
+          aws s3 cp dist/404.html s3://WILL_ADD_WALLET_S3/404.html \
+            --cache-control "no-cache,no-store,must-revalidate"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id WILL_ADD_CLOUDFRONT_DISTRIBUTION_ID \
+            --paths "/*"

--- a/src/pages/WalletHome.tsx
+++ b/src/pages/WalletHome.tsx
@@ -3,11 +3,87 @@ import { PassphraseGate } from "../components/PassphraseGate";
 import { useWallet } from "../context/useWallet";
 import { createAuthRequest, SUPPORTED_IDPS } from "@lib/api/keycloak";
 import { getAllCredentials } from "@lib/credential-store";
+import { fetchBitstring } from "@lib/api/bitstring";
 import type { VerifiableCredential } from "@lib/types";
+
+type CredentialStatus =
+  | "loading"
+  | "active"
+  | "revoked"
+  | "expired"
+  | "unavailable";
+
+function checkBit(bitstring: Uint8Array, index: number): boolean {
+  const byteIndex = Math.floor(index / 8);
+  const bitPos = 7 - (index % 8);
+  return ((bitstring[byteIndex] >> bitPos) & 1) === 1;
+}
+
+async function resolveStatus(
+  cred: VerifiableCredential,
+): Promise<CredentialStatus> {
+  const bitstringResult = await fetchBitstring(
+    cred.credentialStatus.statusListCredential,
+  );
+  if (bitstringResult.isErr()) return "unavailable";
+  const index = parseInt(cred.credentialStatus.statusListIndex, 10);
+  if (checkBit(bitstringResult.value, index)) return "revoked";
+  if (new Date(cred.expirationDate) < new Date()) return "expired";
+  return "active";
+}
+
+const STATUS_STYLES: Record<
+  CredentialStatus,
+  { label: string; color: string; bg: string }
+> = {
+  loading: { label: "Checking...", color: "#888", bg: "#f0f0f0" },
+  active: { label: "Active", color: "#fff", bg: "#22863a" },
+  revoked: { label: "Revoked", color: "#fff", bg: "#cb2431" },
+  expired: { label: "Expired", color: "#fff", bg: "#b08800" },
+  unavailable: { label: "Status unavailable", color: "#888", bg: "#e0e0e0" },
+};
+
+function StatusBadge({ status }: { status: CredentialStatus }) {
+  const s = STATUS_STYLES[status];
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 10px",
+        borderRadius: "12px",
+        fontSize: "0.78rem",
+        fontWeight: 600,
+        letterSpacing: "0.04em",
+        color: s.color,
+        backgroundColor: s.bg,
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}
+
+function credentialLabel(type: string[]): string {
+  const meaningful = type.filter((t) => t !== "VerifiableCredential");
+  return meaningful.length > 0
+    ? meaningful.join(", ")
+    : "Verifiable Credential";
+}
+
+function issuerLabel(issuer: string): string {
+  try {
+    return new URL(issuer).hostname;
+  } catch {
+    return issuer;
+  }
+}
 
 export function WalletHome() {
   const { key } = useWallet();
   const [credentials, setCredentials] = useState<VerifiableCredential[]>([]);
+  const [statuses, setStatuses] = useState<Map<string, CredentialStatus>>(
+    new Map(),
+  );
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,6 +100,18 @@ export function WalletHome() {
         (creds) => {
           setCredentials(creds);
           setLoaded(true);
+
+          const initial = new Map<string, CredentialStatus>(
+            creds.map((c) => [c.id, "loading"]),
+          );
+          setStatuses(initial);
+
+          creds.forEach((cred) => {
+            resolveStatus(cred).then((status) => {
+              if (cancelled) return;
+              setStatuses((prev) => new Map(prev).set(cred.id, status));
+            });
+          });
         },
         (err) => {
           setError(`Failed to load credentials: ${err.message}`);
@@ -64,43 +152,45 @@ export function WalletHome() {
       ) : credentials.length > 0 ? (
         <div>
           <h2>Your Credentials</h2>
-          {credentials.map((cred) => (
-            <div
-              key={cred.id}
-              style={{
-                border: "1px solid #ccc",
-                borderRadius: "4px",
-                padding: "1rem",
-                marginBottom: "1rem",
-              }}
-            >
-              <p>
-                <strong>Type:</strong> {cred.type.join(", ")}
-              </p>
-              <p>
-                <strong>Issuer:</strong> {cred.issuer}
-              </p>
-              <p>
-                <strong>Subject:</strong>
-              </p>
-              <ul style={{ marginLeft: "1.5rem" }}>
-                <li>
-                  Name: {cred.credentialSubject.given_name}{" "}
-                  {cred.credentialSubject.family_name}
-                </li>
-                <li>Email: {cred.credentialSubject.email}</li>
-                <li>Status: {cred.credentialSubject.enrollment_status}</li>
-              </ul>
-              <p>
-                <strong>Issued:</strong>{" "}
-                {new Date(cred.issuanceDate).toLocaleDateString()}
-              </p>
-              <p>
-                <strong>Expires:</strong>{" "}
-                {new Date(cred.expirationDate).toLocaleDateString()}
-              </p>
-            </div>
-          ))}
+          {credentials.map((cred) => {
+            const status = statuses.get(cred.id) ?? "loading";
+            return (
+              <div
+                key={cred.id}
+                style={{
+                  border: "1px solid #ccc",
+                  borderRadius: "4px",
+                  padding: "1rem",
+                  marginBottom: "1rem",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    marginBottom: "0.5rem",
+                  }}
+                >
+                  <strong style={{ fontSize: "1rem" }}>
+                    {credentialLabel(cred.type)}
+                  </strong>
+                  <StatusBadge status={status} />
+                </div>
+                <p style={{ margin: "0.25rem 0" }}>
+                  <strong>Institution:</strong> {issuerLabel(cred.issuer)}
+                </p>
+                <p style={{ margin: "0.25rem 0" }}>
+                  <strong>Issued:</strong>{" "}
+                  {new Date(cred.issuanceDate).toLocaleDateString()}
+                </p>
+                <p style={{ margin: "0.25rem 0" }}>
+                  <strong>Expires:</strong>{" "}
+                  {new Date(cred.expirationDate).toLocaleDateString()}
+                </p>
+              </div>
+            );
+          })}
         </div>
       ) : (
         <p>No credentials found. Get one to get started!</p>


### PR DESCRIPTION
## Summary
- Display credential type, institution, issuance date, expiration date on credential card
- Fetch and decompress S3 bitstring on wallet load, check bit at revocation_index
- Show color-coded status badge: Active / Revoked / Expired / Status unavailable
- Replace GitHub Pages deploy with S3 + CloudFront GitHub Actions workflow
- Still need to update the wallet s3 and cloudfront once created in infra

## Issues
This resolve #3

## Test plan
havent been able to test it