### PR TITLE
feat: Credential Revocation Status Display

### DIFF
--- a/src/lib/api/bitstring.ts
+++ b/src/lib/api/bitstring.ts
@@ -6,9 +6,10 @@ export interface BitstringError {
 
 export function fetchBitstring(
   url: string,
+  signal?: AbortSignal,
 ): ResultAsync<Uint8Array, BitstringError> {
   return ResultAsync.fromPromise(
-    fetch(url)
+    fetch(url, { signal })
       .then((res) => {
         if (!res.ok)
           throw new Error(

--- a/src/pages/WalletHome.tsx
+++ b/src/pages/WalletHome.tsx
@@ -3,27 +3,109 @@ import { PassphraseGate } from "../components/PassphraseGate";
 import { useWallet } from "../context/useWallet";
 import { createAuthRequest, SUPPORTED_IDPS } from "@lib/api/keycloak";
 import { getAllCredentials } from "@lib/credential-store";
+import { fetchBitstring } from "@lib/api/bitstring";
 import type { VerifiableCredential } from "@lib/types";
+
+type RevocationStatus = "loading" | "active" | "revoked" | "unavailable";
+
+function checkBit(bitstring: Uint8Array, index: number): boolean {
+  const byteIndex = Math.floor(index / 8);
+  const bitIndex = 7 - (index % 8);
+  return ((bitstring[byteIndex] >> bitIndex) & 1) === 1;
+}
+
+async function resolveRevocationStatuses(
+  creds: VerifiableCredential[],
+  signal: AbortSignal,
+): Promise<Map<string, RevocationStatus>> {
+  const byUrl = new Map<string, VerifiableCredential[]>();
+  for (const cred of creds) {
+    const url = cred.credentialStatus.statusListCredential;
+    const group = byUrl.get(url) ?? [];
+    group.push(cred);
+    byUrl.set(url, group);
+  }
+
+  const result = new Map<string, RevocationStatus>();
+
+  await Promise.all(
+    Array.from(byUrl.entries()).map(async ([url, group]) => {
+      const bitstringResult = await fetchBitstring(url, signal);
+      for (const cred of group) {
+        const index = parseInt(cred.credentialStatus.statusListIndex, 10);
+        result.set(
+          cred.id,
+          bitstringResult.match(
+            (bitstring) => (checkBit(bitstring, index) ? "revoked" : "active"),
+            () => "unavailable",
+          ),
+        );
+      }
+    }),
+  );
+
+  return result;
+}
+
+const STATUS_STYLES: Record<
+  RevocationStatus,
+  { label: string; bg: string; color: string }
+> = {
+  loading: { label: "Checking...", bg: "#e0e0e0", color: "#555" },
+  active: { label: "Active", bg: "#d4f5d4", color: "#1a7f37" },
+  revoked: { label: "Revoked", bg: "#ffd4d4", color: "#cb2431" },
+  unavailable: { label: "Status unavailable", bg: "#f5f5f5", color: "#888" },
+};
+
+function StatusBadge({ status }: { status: RevocationStatus }) {
+  const { label, bg, color } = STATUS_STYLES[status];
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        borderRadius: "12px",
+        fontSize: "0.8rem",
+        fontWeight: 600,
+        background: bg,
+        color,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
 
 export function WalletHome() {
   const { key } = useWallet();
   const [credentials, setCredentials] = useState<VerifiableCredential[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [statuses, setStatuses] = useState<Map<string, RevocationStatus>>(
+    new Map(),
+  );
 
   const loading = key !== null && !loaded;
 
   useEffect(() => {
     if (!key) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
 
     getAllCredentials(key).then((result) => {
-      if (cancelled) return;
+      if (controller.signal.aborted) return;
       result.match(
         (creds) => {
           setCredentials(creds);
           setLoaded(true);
+          setStatuses(new Map(creds.map((c) => [c.id, "loading"])));
+
+          resolveRevocationStatuses(creds, controller.signal).then(
+            (resolved) => {
+              if (controller.signal.aborted) return;
+              setStatuses(resolved);
+            },
+          );
         },
         (err) => {
           setError(`Failed to load credentials: ${err.message}`);
@@ -33,7 +115,7 @@ export function WalletHome() {
     });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [key]);
 
@@ -74,6 +156,21 @@ export function WalletHome() {
                 marginBottom: "1rem",
               }}
             >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginBottom: "0.5rem",
+                }}
+              >
+                <strong>
+                  {cred.type
+                    .filter((t) => t !== "VerifiableCredential")
+                    .join(", ") || "VerifiableCredential"}
+                </strong>
+                <StatusBadge status={statuses.get(cred.id)!} />
+              </div>
               <p>
                 <strong>Type:</strong> {cred.type.join(", ")}
               </p>


### PR DESCRIPTION
## Summary
- Fetches gzip-compressed W3C BitstringStatusList on credential view load and reads the bit at `statusListIndex`
- Displays **Active** (green), **Revoked** (red), or **Status unavailable** (gray) badge on each credential card
- Deduplicates fetches — credentials sharing the same `statusListCredential` URL make only one network request
- `AbortController` cancels in-flight fetches on component unmount

## Test plan
- Open wallet with an active credential — badge shows "Active"
- Simulate a revoked bit (bit=1 at index) — badge shows "Revoked"
- Take network offline — badge shows "Status unavailable", credential still visible
- Navigate away mid-load — verify no state update warnings in console